### PR TITLE
Conditionally compile debug overlay and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ RenderMeThis is a SwiftUI debugging utility that helps you pinpoint exactly when
 
 Below are two sets of examples demonstrating how to use RenderMeThis. The first set leverages the **wrapper method** (using `RenderCheck`), available on iOS 18+; the second uses the **modifier method** (using `checkForRender()`) for iOS 13+.
 
+### **Debugging vs. Production**
+> Important: RenderMeThis is a development utility intended solely for debugging purposes. The debug overlay—which highlights view re‑renders with a red flash—is conditionally compiled using Swift’s `#if DEBUG` directive. This means that in production builds, the debugging code is automatically excluded, ensuring that your app remains lean without any unintended visual effects or performance overhead.
+
+> Please ensure that your project’s build settings correctly define the DEBUG flag for development configurations. This will guarantee that the render debugging features are active only during development and testing.
+
 ### **Wrapper Method (iOS 18+)**
 
 Wrap your entire view hierarchy with `RenderCheck` to automatically apply render debugging to every subview:

--- a/Sources/RenderMeThis/RenderDebugView.swift
+++ b/Sources/RenderMeThis/RenderDebugView.swift
@@ -36,7 +36,11 @@ struct RenderDebugView<Content: View>: View {
 public extension View {
     /// Wraps the view in a debug wrapper that highlights render updates.
     func checkForRender() -> some View {
-        RenderDebugView(content: self)
+        #if DEBUG
+        return RenderDebugView(content: self)
+        #else
+        return self
+        #endif
     }
 }
 


### PR DESCRIPTION
Introduce conditional compilation for the render debugging overlay.

- Updated the view extension (checkForRender()) to conditionally compile the debug overlay using `#if DEBUG`. In non-debug (production) builds, the overlay is automatically excluded, ensuring no unintended visual effects or performance overhead.

- Added a "Debugging vs. Production" section to the README that explains how the debug overlay is conditionally enabled with the `#if DEBUG` flag. This helps developers understand that the overlay is active only during development and testing.