### PR TITLE
Back deployed `RenderCheck` View to iOS 13+ & macOS 10.15+

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ RenderMeThis is a SwiftUI debugging utility that helps you pinpoint exactly when
 
 ## **Usage**
 
-Below are two sets of examples demonstrating how to use RenderMeThis. The first set leverages the **wrapper method** (using `RenderCheck`), available on iOS 18+; the second uses the **modifier method** (using `checkForRender()`) for iOS 13+.
+Below are two sets of examples demonstrating how to use RenderMeThis. The first set leverages the **wrapper method** (using `RenderCheck`), available on iOS 13+; the second uses the **modifier method** (using `checkForRender()`) for iOS 13+.
 
 ### **Debugging vs. Production**
 > Important: RenderMeThis is a development utility intended solely for debugging purposes. The debug overlay—which highlights view re‑renders with a red flash—is conditionally compiled using Swift’s `#if DEBUG` directive. This means that in production builds, the debugging code is automatically excluded, ensuring that your app remains lean without any unintended visual effects or performance overhead.
 
 > Please ensure that your project’s build settings correctly define the DEBUG flag for development configurations. This will guarantee that the render debugging features are active only during development and testing.
 
-### **Wrapper Method (iOS 18+)**
+### **Wrapper Method**
 
 Wrap your entire view hierarchy with `RenderCheck` to automatically apply render debugging to every subview:
 
@@ -128,7 +128,7 @@ struct ContentSubView: View {
 ```
 
 
-### **Modifier Method (iOS 13+)**
+### **Modifier Method**
 
 Apply the render debugging effect to individual views using the `checkForRender()` modifier:
 

--- a/Sources/RenderMeThis/LocalRenderManager.swift
+++ b/Sources/RenderMeThis/LocalRenderManager.swift
@@ -1,5 +1,5 @@
 //
-//  LocalRenderManager.swift.swift
+//  LocalRenderManager.swift
 //  RenderMeThis
 //
 //  Created by Aether on 12/03/2025.
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-@MainActor
 // swift's concurrency model is allergic to implicit cross-actor accesses
 // (this just means swift gets mad if you try to update something on the main thread
 // from a background thread without explicitly telling it that's okay),
@@ -16,6 +15,7 @@ import SwiftUI
 // making the whole class `@MainActor` prevents data race errors
 // (aka, two parts of your code accidentally changing the same thing at the same time and
 // causing weird unpredictable bugs) while keeping things consistent.
+@MainActor
 class LocalRenderManager: ObservableObject {
     var id = UUID()
     @Published var rendered: Bool = false

--- a/Sources/RenderMeThis/RMTDemoView.swift
+++ b/Sources/RenderMeThis/RMTDemoView.swift
@@ -55,11 +55,14 @@ struct RMTDemoView: View {
                         .tag(2)
                 }
                 .ignoresSafeArea()
+                #if os(iOS)
                 .tabViewStyle(.page(indexDisplayMode: .never))
+                #endif
             }
             .searchable(text: $searchText, prompt: "Search")
             .navigationTitle("RenderMeThis")
             .toolbar {
+                #if os(iOS)
                 ToolbarItem(placement: .topBarTrailing) {
                     Button(action: {
                         isShowingSheet.toggle()
@@ -67,6 +70,15 @@ struct RMTDemoView: View {
                         Image(systemName: "info.circle")
                     }
                 }
+                #else
+                ToolbarItem(placement: .primaryAction) {
+                    Button(action: {
+                        isShowingSheet.toggle()
+                    }) {
+                        Image(systemName: "info.circle")
+                    }
+                }
+                #endif
             }
             .sheet(isPresented: $isShowingSheet) {
                 aboutView

--- a/Sources/RenderMeThis/RenderCheck.swift
+++ b/Sources/RenderMeThis/RenderCheck.swift
@@ -9,25 +9,39 @@ import SwiftUI
 
 /// A convenience view that applies the rendering debug wrapper to each subview.
 /// (basically, it wraps every subview with the modifier that detects when it re-renders)
-@available(macOS 15, *)
-@available(iOS 18.0, *)
-// only available on iOS 18+ macOS 15+ (because it uses new SwiftUI APIs)
 public struct RenderCheck<Content: View>: View {
-    @ViewBuilder let content: Content
     // `@ViewBuilder` lets you pass multiple views as `content`
     // (so you can just throw a bunch of views inside `RenderCheck` without explicitly grouping them)
+    @ViewBuilder let content: Content
     
     public init(@ViewBuilder content: () -> Content) {
         self.content = content()
     }
     
     public var body: some View {
-        Group(subviews: content) { subviewsCollection in
-            subviewsCollection
-            // This is just passing the subviews along untouched (I hope??)
-            // (the real work happens in `.checkForRender()`)
+        // This is just passing the subviews along untouched (I hope??)
+        // (the real work happens in `.checkForRender()`)
+        if #available(macOS 15, iOS 18, *) {
+            Group(subviews: content) { subviewsCollection in
+                subviewsCollection
+            }
+            .checkForRender() // Highlights views that re-render (that's the whole point of this tool)
+        } else {
+            _VariadicView.Tree(_RenderCheckGroup()) {
+                content
+                    .checkForRender()
+            }
         }
-        .checkForRender()
-        // Highlights views that re-render (that's the whole point of this tool)
+    }
+}
+
+// MARK: - Back Deploy
+
+fileprivate struct _RenderCheckGroup: _VariadicView_MultiViewRoot {
+    func body(children: _VariadicView.Children) -> some View {
+        ForEach(children) { child in
+            child
+                .checkForRender()
+        }
     }
 }

--- a/Sources/RenderMeThis/RenderDebugView.swift
+++ b/Sources/RenderMeThis/RenderDebugView.swift
@@ -5,7 +5,6 @@
 //  Created by Aether on 12/03/2025.
 //
 
-
 import SwiftUI
 
 /// A debugging wrapper that highlights when a view is re‑initialized.

--- a/Sources/RenderMeThis/RenderMeThis.swift
+++ b/Sources/RenderMeThis/RenderMeThis.swift
@@ -1,2 +1,0 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book


### PR DESCRIPTION
### Motivation

I know there're something **undocumented but also public** APIs in SwiftUI like `_VariadicView`, etc.

Basically, the new APIs are built on top of that, so it's possible to add support to very old systems.

After merging this PR, developers can be very happy to just use the wrapper method to boost their productivity.

Also, this PR includes compilation fix for macOS and other minor changes that will help the package get better :) 

### What's Changed

- Add `_RenderCheckGroup` for back deployment (marked it `fileprivate` because we are only gonna use it internally)
- Rename `LocalRenderManager.swift.swift` to `LocalRenderManager.swift`
- Little adjustments to the order of code and comments
- Remove empty placeholder file `RemindMeThis.swift`
- Fix compile issues in `RMTDemoView.swift` for macOS
- Update `README.md` file based on the new implementation (no iOS 18 restrictions)

### Resources Related
- [SwiftUI under the Hood: Variadic Views](https://movingparts.io/variadic-views-in-swiftui)
- [How to use VariadicView, SwiftUI's Private View API](https://www.emergetools.com/blog/posts/how-to-use-variadic-view)
- [Variadic Views by Chris Eidhof](https://chris.eidhof.nl/post/variadic-views/)
- [Secret SwiftUI: A practical use of _VariadicView](https://blog.jacobstechtavern.com/p/secret-swiftui)