### PR TITLE
Remove Update Print Statement

### DIFF
--- a/Sources/RenderMeThis/RenderDebugView.swift
+++ b/Sources/RenderMeThis/RenderDebugView.swift
@@ -17,7 +17,6 @@ struct RenderDebugView<Content: View>: View {
     init(content: Content) {
         self.content = content
         self.renderManager = LocalRenderManager()
-        print("RenderDebugView init triggered")
         renderManager.triggerRender()
     }
     


### PR DESCRIPTION
I'm not sure whether people find this print valuable in their workflow to detect changes (beyond the flash), but in my app I find it rather distracting and spammy in comparison to my other logs so wanted to disable it.

PR removes it completely, but could make it configurable if some folks find value in this 🙂 